### PR TITLE
HC5 proxy

### DIFF
--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
@@ -21,7 +21,6 @@ import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
@@ -43,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import at.asit.pdfover.commons.Constants;
 import at.asit.pdfover.commons.Messages;
 import at.asit.pdfover.gui.bku.mobile.ATrustParser;
+import at.asit.pdfover.gui.utils.HttpClientUtils;
 import at.asit.pdfover.gui.workflow.states.MobileBKUState;
 import at.asit.pdfover.gui.workflow.states.MobileBKUState.UsernameAndPassword;
 import at.asit.pdfover.signer.BkuSlConnector;
@@ -77,7 +77,7 @@ public class MobileBKUConnector implements BkuSlConnector {
     @Override
 	public String handleSLRequest(PdfAs4SLRequest slRequest) throws SignatureException, UserCancelledException {
         log.debug("Got security layer request: (has file part: {})\n{}", (slRequest.signatureData != null), slRequest.xmlRequest);
-        try (final CloseableHttpClient httpClient = HttpClients.custom().disableRedirectHandling().useSystemProperties().build()) {
+        try (final CloseableHttpClient httpClient = HttpClientUtils.builderWithSettings().disableRedirectHandling().build()) {
             ClassicHttpRequest currentRequest = buildInitialRequest(slRequest);
             ATrustParser.Result response;
             while ((response = sendHTTPRequest(httpClient, currentRequest)).slResponse == null)
@@ -242,7 +242,7 @@ public class MobileBKUConnector implements BkuSlConnector {
 
     private static class LongPollThread extends Thread implements AutoCloseable {
         
-        private final CloseableHttpClient httpClient = HttpClients.createDefault();
+        private final CloseableHttpClient httpClient = HttpClientUtils.builderWithSettings().build();
         private final HttpGet request;
         private final Runnable signal;
         private boolean done = false;

--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
@@ -76,7 +76,7 @@ public class MobileBKUConnector implements BkuSlConnector {
     @Override
 	public String handleSLRequest(PdfAs4SLRequest slRequest) throws SignatureException, UserCancelledException {
         log.debug("Got security layer request: (has file part: {})\n{}", (slRequest.signatureData != null), slRequest.xmlRequest);
-        try (final CloseableHttpClient httpClient = HttpClients.custom().disableRedirectHandling().build()) {
+        try (final CloseableHttpClient httpClient = HttpClients.custom().disableRedirectHandling().useSystemProperties().build()) {
             ClassicHttpRequest currentRequest = buildInitialRequest(slRequest);
             ATrustParser.Result response;
             while ((response = sendHTTPRequest(httpClient, currentRequest)).slResponse == null)

--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
@@ -127,6 +128,7 @@ public class MobileBKUConnector implements BkuSlConnector {
 
             if (httpStatus != HttpStatus.SC_OK) {
                 switch (httpStatus) {
+                    case HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED: throw new UserDisplayedError(Messages.getString("error.ProxyAuthRequired"));
                     case HttpStatus.SC_REQUEST_TOO_LONG: throw new UserDisplayedError(Messages.getString("atrusterror.http_413"));
                     default: throw new UserDisplayedError(Messages.formatString("atrusterror.http_generic", httpStatus, Optional.ofNullable(response.getReasonPhrase()).orElse("(null)")));
                 }
@@ -163,6 +165,9 @@ public class MobileBKUConnector implements BkuSlConnector {
             } else {
                 return ATrustParser.Parse(request.getUri(), contentType.getMimeType(), entityBody);
             }
+        } catch (ClientProtocolException e) {
+            log.warn("Failed to connect:", e);
+            throw new UserDisplayedError(Messages.formatString("error.FailedToConnect", e.getLocalizedMessage()));
         }
     }
 

--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/utils/HttpClientUtils.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/utils/HttpClientUtils.java
@@ -1,0 +1,10 @@
+package at.asit.pdfover.gui.utils;
+
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+
+public final class HttpClientUtils {
+    public static HttpClientBuilder builderWithSettings() {
+        return HttpClients.custom().useSystemProperties();
+    }
+}

--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/workflow/states/MobileBKUState.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/workflow/states/MobileBKUState.java
@@ -33,7 +33,6 @@ import at.asit.webauthnclient.responsefields.AuthenticatorAssertionResponse;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
@@ -52,6 +51,7 @@ import at.asit.pdfover.gui.composites.mobilebku.MobileBKUQRComposite;
 import at.asit.pdfover.gui.composites.mobilebku.WaitingForAppComposite;
 import at.asit.pdfover.gui.controls.Dialog.BUTTONS;
 import at.asit.pdfover.gui.controls.Dialog.ICON;
+import at.asit.pdfover.gui.utils.HttpClientUtils;
 import at.asit.pdfover.gui.controls.Dialog;
 import at.asit.pdfover.gui.controls.ErrorDialog;
 import at.asit.pdfover.commons.Messages;
@@ -369,7 +369,7 @@ public class MobileBKUState extends State {
 	 * this method will return immediately */
 	public void showQRCode(final @Nonnull String referenceValue, @Nonnull URI qrCodeURI, @Nullable URI signatureDataURI, final boolean showSmsTan, final boolean showFido2, final @Nullable String errorMessage) {
 		byte[] qrCode;
-		try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+		try (final CloseableHttpClient httpClient = HttpClientUtils.builderWithSettings().build()) {
 			try (final CloseableHttpResponse response = httpClient.execute(new HttpGet(qrCodeURI))) {
 				qrCode = EntityUtils.toByteArray(response.getEntity());
 			}

--- a/pdf-over-gui/src/main/resources/at/asit/pdfover/gui/messages.properties
+++ b/pdf-over-gui/src/main/resources/at/asit/pdfover/gui/messages.properties
@@ -172,6 +172,7 @@ error.TanTooLong=Entered TAN too long
 error.Title=Error
 error.TitleFatal=Fatal Error
 error.Unexpected=Unexpected Error
+error.ProxyAuthRequired=HTTP proxy refused connection:\nHTTP/1.1 407 Proxy Authentication Required
 exception.InvalidEmblemFile=%s is an invalid signature logo file\!
 exception.InvalidPort=%s is invalid\: has to be a number between %d and %d
 exception.PasswordTooLong=Given password is too long\!

--- a/pdf-over-gui/src/main/resources/at/asit/pdfover/gui/messages_de.properties
+++ b/pdf-over-gui/src/main/resources/at/asit/pdfover/gui/messages_de.properties
@@ -169,6 +169,7 @@ error.Unexpected=Unerwarteter Fehler
 error.ATrustConnection=Verbindung zu A-Trust konnte nicht aufgebaut werden
 error.CouldNotResolveHostname=Server '%s' wurde nicht gefunden.\nÜberprüfen Sie Ihre Internetverbindung.
 error.FailedToConnect=Verbindung zum Signaturserver fehlgeschlagen:\n%s
+error.ProxyAuthRequired=HTTP-Proxy lehnt Verbindung ab:\nHTTP/1.1 407 Proxy Authentication Required
 exception.InvalidEmblemFile=%s ist eine ungültige Bildmarken-Datei\!
 exception.InvalidPort=%s ist ungültig\: muss eine Nummer zwischen %d und %d sein.
 exception.PasswordTooLong=Eingegebenes Passwort ist zu lange\!


### PR DESCRIPTION
HttpClient5 decided to stop using proxy system properties unless you explicitly ask for it.

We now explicitly ask for it. Closes #36.