### PR TITLE
Do not reset empty signature note on restart

### DIFF
--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/workflow/config/ConfigurationManager.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/workflow/config/ConfigurationManager.java
@@ -21,6 +21,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Properties;
 
 import javax.annotation.CheckForNull;
@@ -301,7 +302,7 @@ public class ConfigurationManager {
 		setPropertyIfNotNull(props, Constants.CFG_EMBLEM, getDefaultEmblemPersistent());
 		setProperty(props, Constants.CFG_LOGO_ONLY_SIZE, ISNOTNULL(Double.toString(getLogoOnlyTargetSize())));
 		
-		setPropertyIfNotNull(props, Constants.CFG_SIGNATURE_NOTE, getSignatureNote());
+		setProperty(props, Constants.CFG_SIGNATURE_NOTE, ISNOTNULL(Objects.requireNonNullElse(getSignatureNote(), "")));
 		setPropertyIfNotNull(props, Constants.CFG_MOBILE_NUMBER, getDefaultMobileNumberPersistent());
 		if (getRememberMobilePassword())
 			setProperty(props, Constants.CFG_MOBILE_PASSWORD_REMEMBER, Constants.TRUE);


### PR DESCRIPTION
Title. Before, setting the signature note to be empty would cause it to reset to the default note on app restart.