### PR TITLE
Give nightly integration the necessary permissions to comment...

### DIFF
--- a/.github/workflows/nighty-link-pr-comment.yml
+++ b/.github/workflows/nighty-link-pr-comment.yml
@@ -69,3 +69,8 @@ jobs:
             for (const pr of pull_requests) {
               await upsertComment(owner, repo, pr.number, run_name, link);
             }
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write


### PR DESCRIPTION
I am extremely annoyed that the CI file worked in the test fork, and now fails here...