### PR TITLE
Do not attempt to draw zero-size image backdrop

### DIFF
--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/controls/MainBarButton.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/controls/MainBarButton.java
@@ -299,9 +299,10 @@ public abstract class MainBarButton extends Canvas {
 	 */
 	protected void paintText(PaintEvent e) {
 		Point size = this.getSize();
-		int height = size.y;
-
-		int width = size.x;
+		final int height = size.y;
+		final int width = size.x;
+		if ((height == 0) || (width == 0))
+			return;
 
 		// e.gc.fillGradientRectangle(0, 1, width, height / 4, true);
 
@@ -336,7 +337,7 @@ public abstract class MainBarButton extends Canvas {
 
 			int w = 0;
 			Image tmp = null;
-			if(this.image.getImageData().width < width) {
+			if (this.image.getImageData().width < width) {
 				tmp = new Image(getDisplay(), this.image.getImageData());
 				w = (width - this.image.getImageData().width) / 2;
 			} else if(this.image.getImageData().width > width) {


### PR DESCRIPTION
If the main flow halts on a dialog box in GTK3 rendering mode, this can cause the rendering callback on the main menu bar buttons to be invoked with size 0/0. This results in an attempt to resize the background image to 0/0, which throws and takes the entire process with it.

Closes #78.