### PR TITLE
Smoother rendering via rendering hints

### DIFF
--- a/pdf-over-commons/src/main/java/at/asit/pdfover/commons/utils/ImageUtil.java
+++ b/pdf-over-commons/src/main/java/at/asit/pdfover/commons/utils/ImageUtil.java
@@ -167,9 +167,14 @@ public final class ImageUtil {
 	}
 
 	public static java.awt.Image debugDisplayImage(java.awt.Image image) {
-		JPanel panel = new JPanel();
-		panel.add(new JLabel(new ImageIcon(image)));
-		JOptionPane.showMessageDialog(null, new JScrollPane(panel));
+		// note that the image does not render correctly
+		// if this function is called from an AWT Event thread
+		// wrapping it all in a thread seams to fix the problem
+		new Thread(() -> {
+			JPanel panel = new JPanel();
+			panel.add(new JLabel(new ImageIcon(image)));
+			JOptionPane.showMessageDialog(null, new JScrollPane(panel));
+		}).start();
 		return image;
 	}
 

--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/composites/SignaturePanel.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/composites/SignaturePanel.java
@@ -16,28 +16,23 @@
 package at.asit.pdfover.gui.composites;
 
 // Imports
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Cursor;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Image;
+
+import at.asit.pdfover.commons.Messages;
+import at.asit.pdfover.signer.pdfas.PdfAs4SignatureParameter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-
-import javax.swing.JPanel;
-
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.rendering.PDFRenderer;
-
-import at.asit.pdfover.commons.Messages;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  *
@@ -168,14 +163,13 @@ public class SignaturePanel extends JPanel {
 	/**
 	 * Set the signature placeholder image
 	 * @param placeholder signature placeholder
-	 * @param width width of the placeholder in page space
-	 * @param height height of the placeholder in page space
 	 */
 	public void setSignaturePlaceholder(Image placeholder) {
 		this.sigPlaceholder = placeholder;
-		// TODO figure out why this is divided by 4 (factor ported from old code)
-		this.sigPageWidth = placeholder.getWidth(null) / 4;
-		this.sigPageHeight = placeholder.getHeight(null) / 4;
+
+		// the size gets scaled down so it looks better
+		this.sigPageWidth = placeholder.getWidth(null) / PdfAs4SignatureParameter.SIG_PREVIEW_SCALING_FACTOR;
+		this.sigPageHeight = placeholder.getHeight(null) / PdfAs4SignatureParameter.SIG_PREVIEW_SCALING_FACTOR;
 		renderPageToImage();
 		if (this.sigPagePos != null)
 			setSignaturePosition(this.sigPagePos.getX(), this.sigPagePos.getY());
@@ -304,6 +298,15 @@ public class SignaturePanel extends JPanel {
 		Dimension renderPanelSize = getSize();
 		g.setColor(getBackground());
 		g.fillRect(0, 0, getWidth(), getHeight());
+
+		if (g instanceof Graphics2D){
+			// this will make the rendering look much better
+			var g2d = ((Graphics2D) g);
+			g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+			g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+			g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+		}
+
 		if (this.currentImage == null) {
 			g.setColor(Color.black);
 			g.drawString(Messages.getString("common.working"), getWidth() / 2 - 30, getHeight() / 2);


### PR DESCRIPTION
In the signture panel where the pdf page and the signature preview is painted, I added antialiasing and bicubic interpolation rendering hints so the scaled images don't look as jagged and much smoother. Specifically I added bicubic filtering, anti aliasing and setting the prefered rendering to the quality setting. I also added a constant for the magic value that was used to downscale the signature preview image in `SignaturePanel.setSignaturePlaceholder(...)`. It was used because when we request a signature preview from `PdfAs.generateVisibleSignaturePreview(...)` we upscaled the resolution by that factor. I guess downscaling to get better image quality was already an idea. I this reduced the scaling from 4 to 2 because this seemed to give nicer results.

I tested it that it compiles with `mvn -U install`.

In the future I might add a setting to modify the filtering settings, because somebody out there might be running this on weak hardware and prefers speed over looks.

I included two screenshots of the difference in rendering so one can easily compare them, I think it looks better ;)
![jagged_without_hints](https://github.com/a-sit/PDF-Over/assets/27574891/7bb42834-cea6-4f11-a4a1-13492b7927dd)
![smooth_with_hints](https://github.com/a-sit/PDF-Over/assets/27574891/9bbc1021-a860-4c20-8490-9217e51bf7a1)
