### PR TITLE
revert version to 4.4.6-SNAPSHOT

### DIFF
--- a/pdf-over-commons/pom.xml
+++ b/pdf-over-commons/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<artifactId>pdf-over</artifactId>
 		<groupId>at.a-sit</groupId>
-		<version>4.4.7-SNAPSHOT</version>
+		<version>4.4.6-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>pdf-over-commons</artifactId>
-	<version>4.4.7-SNAPSHOT</version>
+	<version>4.4.6-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pdf-over-gui/pom.xml
+++ b/pdf-over-gui/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>pdf-over</artifactId>
 		<groupId>at.a-sit</groupId>
-		<version>4.4.7-SNAPSHOT</version>
+		<version>4.4.6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>pdf-over-gui</artifactId>

--- a/pdf-over-signer/pom.xml
+++ b/pdf-over-signer/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>pdf-over</artifactId>
 		<groupId>at.a-sit</groupId>
-		<version>4.4.7-SNAPSHOT</version>
+		<version>4.4.6-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>pdf-over-signer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>at.a-sit</groupId>
 	<artifactId>pdf-over</artifactId>
-	<version>4.4.7-SNAPSHOT</version>
+	<version>4.4.6-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>PDF-Over</name>


### PR DESCRIPTION
The 4.4.6 release was never published, so we're going back to 4.4.6-SNAPSHOT on the unstable branch.