### PR TITLE
Adjust long polling failure handling

### DIFF
--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
@@ -300,11 +300,14 @@ public class MobileBKUConnector implements BkuSlConnector {
         @Override
         public void close() {
             done = true;
+
             if (this.request != null)
                 this.request.abort();
 
-            if (this.isAlive())
+            if (this.isAlive()) {
+                this.interrupt();
                 try { this.join(1000); } catch (InterruptedException e) {}
+            }
             
             if (this.httpClient != null)
                 try { this.httpClient.close(); } catch (IOException e) { log.warn("Auto-close of long-poll HTTP client threw exception", e); }

--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
@@ -278,8 +278,10 @@ public class MobileBKUConnector implements BkuSlConnector {
                 } catch (Exception e) {
                     if (done) break;
                     log.warn("QR code long polling exception", e);
-                    /* sleep so we don't hammer a-trust too hard in case this goes wrong */
-                    try { Thread.sleep(5000); } catch (InterruptedException e2) {}
+
+                    /* A-Trust does excepting handling this way, so we copy it (they might mask errors, so we should too...) */
+                    try { Thread.sleep(10000); } catch (InterruptedException e2) {}
+                    signalProbablyDone();
                 }
             }
             log.debug("LongPollThread goodbye");


### PR DESCRIPTION
Match A-Trust exception handling for long polling; wait 10 seconds then retry.
This should hopefully ensure that any errors they mask, we also mask...

cf. #117 