### PR TITLE
Fix HttpClient hanging if 5+ redirects are followed

### DIFF
--- a/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
+++ b/pdf-over-gui/src/main/java/at/asit/pdfover/gui/bku/MobileBKUConnector.java
@@ -167,7 +167,6 @@ public class MobileBKUConnector implements BkuSlConnector {
 	            }
 	        } catch (Exception e) {
 	            log.debug("Failed to connect:", e);
-	            e.printStackTrace();
 	            throw new UserDisplayedError(Messages.formatString("error.FailedToConnect", e.getLocalizedMessage()));
 	        }
         }


### PR DESCRIPTION
Caused by the tail recursion never exiting the try-with-resources block.
This can never happen with production users, but only with test identities without a second factor enabled.