### PR TITLE
Feature/debian package builder 

### DIFF
--- a/.github/helper/debian-changelog-generator.sh
+++ b/.github/helper/debian-changelog-generator.sh
@@ -25,6 +25,3 @@ tag=`git tag -l v* | sort -V | tail -1`
 
 echo "Generating changelog done!"
 echo " generated `wc -l debian/changelog` lines."
-
-git tag
-git log

--- a/.github/helper/debian-changelog-generator.sh
+++ b/.github/helper/debian-changelog-generator.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -o errexit   # abort on nonzero exitstatus
+set -o nounset   # abort on unbound variable
+set -o pipefail  # don't hide errors within pipes
+
+pwd
+cd ./pdf-over-build
+ls
+
+
+mkdir debian
+touch debian/changelog
+
+prevtag="pdf-over-4.0.0"
+pkgname="pdf-over-nightly"
+git tag -l  | sort -V | while read tag; do
+    (echo -e "$pkgname (${tag#pdf-over-}); urgency=medium \n"; git log --pretty=format:'  * %s' $prevtag..$tag; git log --pretty='format:%n%n -- %aN <%aE>  %aD%n%n' $tag^..$tag) | cat - debian/changelog | sponge debian/changelog
+        prevtag=$tag
+done
+
+tag=`git tag -l v* | sort -V | tail -1`
+[ `git log --exit-code $tag..HEAD | wc -l` -ne 0 ] && git-dch -s $tag -S --no-multimaint --nmu --ignore-branch --snapshot-number="'{:%Y%m%d%H%M%S}'.format(__import__('datetime').datetime.fromtimestamp(`git log -1 --pretty=format:%at`))"
+
+#sed -i 's/UNRELEASED/unstable/' debian/changelog
+
+echo "done"

--- a/.github/helper/debian-changelog-generator.sh
+++ b/.github/helper/debian-changelog-generator.sh
@@ -25,3 +25,6 @@ tag=`git tag -l v* | sort -V | tail -1`
 
 echo "Generating changelog done!"
 echo " generated `wc -l debian/changelog` lines."
+
+git tag
+git log

--- a/.github/helper/debian-changelog-generator.sh
+++ b/.github/helper/debian-changelog-generator.sh
@@ -23,4 +23,5 @@ tag=`git tag -l v* | sort -V | tail -1`
 
 #sed -i 's/UNRELEASED/unstable/' debian/changelog
 
-echo "done"
+echo "Generating changelog done!"
+echo " generated `wc -l debian/changelog` lines."

--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -o errexit   # abort on nonzero exitstatus
+set -o nounset   # abort on unbound variable
+set -o pipefail  # don't hide errors within pipes
+
+echo "Hi!"
+

--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -3,5 +3,75 @@ set -o errexit   # abort on nonzero exitstatus
 set -o nounset   # abort on unbound variable
 set -o pipefail  # don't hide errors within pipes
 
-echo "Hi!"
 
+# config:
+NAME="pdf-over-nightly"
+FULLNAME="PDF-Over Nightly"
+VERSION="`date +"%Y%m%d.%H%M%S"`"
+ARCH="all"
+JAR_TARGET="/usr/share/java/$NAME"
+
+
+pwd
+cd ./pdf-over-build
+ls
+
+
+jar_files=""
+cd lib
+for file in *.jar; do
+    if [ -f "$file" ]; then
+        jar_files+="lib/$file=$JAR_TARGET/$file "
+    fi
+done
+cd ..
+
+
+cat > $NAME.sh << EOF
+#!/bin/sh 
+# PDF-Over ($NAME $VERSION) launcher, generated on `date`
+
+GDK_BACKEND=x11,wayland exec java -cp "$JAR_TARGET/*" at.asit.pdfover.gui.Main "\$@"
+EOF
+chmod +x $NAME.sh
+ 
+
+cat > $NAME.desktop << EOF
+[Desktop Entry]
+Version=$VERSION
+Type=Application
+Name=$FULLNAME
+Comment=Create PAdES conforming PDF signatures
+Exec=$NAME
+Icon=$NAME
+Terminal=false
+StartupNotify=false
+Categories=Office
+EOF
+
+
+fpm \
+  -s dir -t deb \
+  -p $NAME-$VERSION-$ARCH.deb \
+  --name $NAME \
+  --license EUPL-1.2 \
+  --version $VERSION \
+  --architecture $ARCH \
+  --deb-upstream-changelog changelog \
+  --depends bash --depends "default-jre | java-runtime (>= 17)" \
+  --description "PDF-Over is your tool for frequent & efficient PDF signing." \
+  --url "https://technology.a-sit.at/en/pdf-over/" \
+  --vendor "A-SIT <software@egiz.gv.at>" \
+  --maintainer "A-SIT <software@egiz.gv.at>" \
+  $jar_files \
+  $NAME.sh=/usr/bin/$NAME \
+  $NAME.desktop=/usr/share/applications/$NAME.desktop \
+  icons/icon144x144.png=/usr/share/pixmaps/$NAME.png
+
+# next: upload/publish $NAME-$VERSION-$ARCH.deb
+
+
+#mkdir experiments
+#mv $NAME-$VERSION-$ARCH.deb experiments
+#cd experiments
+#ar x $NAME-$VERSION-$ARCH.deb

--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -70,7 +70,6 @@ fpm \
   icons/icon144x144.png=/usr/share/pixmaps/$NAME.png
 
 # next: upload/publish $NAME-$VERSION-$ARCH.deb
-cp $NAME-$VERSION-$ARCH.deb $NAME.deb
 
 #mkdir experiments
 #mv $NAME-$VERSION-$ARCH.deb experiments

--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -49,6 +49,7 @@ StartupNotify=false
 Categories=Office
 EOF
 
+fpm --version
 
 fpm \
   -s dir -t deb \
@@ -57,7 +58,7 @@ fpm \
   --license EUPL-1.2 \
   --version $VERSION \
   --architecture $ARCH \
-  --deb-upstream-changelog changelog \
+  --deb-upstream-changelog debian/changelog \
   --depends bash --depends "default-jre | java-runtime (>= 17)" \
   --description "PDF-Over is your tool for frequent & efficient PDF signing." \
   --url "https://technology.a-sit.at/en/pdf-over/" \

--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -70,7 +70,7 @@ fpm \
   icons/icon144x144.png=/usr/share/pixmaps/$NAME.png
 
 # next: upload/publish $NAME-$VERSION-$ARCH.deb
-
+cp $NAME-$VERSION-$ARCH.deb $NAME.deb
 
 #mkdir experiments
 #mv $NAME-$VERSION-$ARCH.deb experiments

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -22,7 +22,8 @@ jobs:
       - name: Install Debian Package Builder dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install packaging-dev git-buildpackage moreutils
+          sudo apt-get install packaging-dev rubygems-integration git-buildpackage moreutils
+          sudo gem install fpm
       - name: Build with Maven
         run: mvn -B clean install -Plinux -Pci-build -Dno-native-profile
       - name: Describe current commit

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: pdf-over-${{ github.event.pull_request.number || github.ref_name }}-${{ env.commit_sha }}-linux-x86_64
-          path: pdf-over-nightly.deb
+          path: pdf-over-build/pdf-over-nightly.deb
 
 permissions:
     contents: read

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -44,12 +46,12 @@ jobs:
         run: bash .github/helper/debian-package-builder.sh
       #- name: Tar bundle
       #  run: tar -C pdf-over-build -cvf pdf-over.tar ./
-      #- name: Upload Build Artifacts
-      #  uses: actions/upload-artifact@v3
-      #  with:
-      #    name: pdf-over-${{ github.event.pull_request.number || github.ref_name }}-${{ env.commit_sha }}-linux-x86_64
-      #    path: pdf-over.tar
+      - name: Upload Debian Package to Build Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: pdf-over-${{ github.event.pull_request.number || github.ref_name }}-${{ env.commit_sha }}-linux-x86_64
+          path: pdf-over-nightly.deb
 
 permissions:
     contents: read
-    #actions: write
+    actions: write

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           cd ppa-nightly
           git config user.name "A-SIT Bot"
-          git config user.email "software@a-sit.at"
+          git config user.email "software@egiz.gv.at"
       - name: Push Debian Package to Nightly PPA
         run: |
           mv pdf-over-build/*.deb ppa-nightly

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -2,8 +2,6 @@ name: Build Debian Package
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -1,9 +1,10 @@
 name: Build Debian Package
 on:
   push:
-    branches: [ "main", "feature/debian" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -47,7 +47,7 @@ jobs:
       #- name: Tar bundle
       #  run: tar -C pdf-over-build -cvf pdf-over.tar ./
       - name: Upload Debian Package to Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pdf-over-nightly-${{ env.commit_sha }}-debian
           path: pdf-over-build/*.deb

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -6,7 +6,7 @@ on:
     branches: [ "main" ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload Debian Package to Build Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: pdf-over-${{ github.event.pull_request.number || github.ref_name }}-${{ env.commit_sha }}-linux-x86_64
+          name: pdf-over-nightly-${{ env.commit_sha }}-debian
           path: pdf-over-build/pdf-over-nightly.deb
 
 permissions:

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -51,6 +51,25 @@ jobs:
         with:
           name: pdf-over-nightly-${{ env.commit_sha }}-debian
           path: pdf-over-build/pdf-over-nightly.deb
+      - name: Init Nightly PPA
+        uses: actions/checkout@v3
+        with:
+          repository: a-sit/ppa-nightly
+          ref: 'main'
+          token:  ${{ secrets.ASIT_PPA_BOT_PPA_NIGHTLY }}
+          path: ppa-nightly
+      - name: Setup Nightly PPA git config
+        run: |
+          cd ppa-nightly
+          git config user.name "A-SIT Bot"
+          git config user.email "software@a-sit.at"
+      - name: Push Debian Package to Nightly PPA
+        run: |
+          mv pdf-over-build/*.deb ppa-nightly
+          cd ppa-nightly
+          git add *.deb
+          git commit -m "New nightly package"
+          git push origin main
 
 permissions:
     contents: read

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
           cache: maven
       - name: Install Debian Package Builder dependencies

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -1,0 +1,48 @@
+name: Build Debian Package
+on:
+  push:
+    branches: [ "main", "feature/debian" ]
+  pull_request:
+    branches: [ "main" ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B clean install -Plinux -Pci-build -Dno-native-profile
+      - name: Describe current commit
+        run: echo "commit_sha=${GITHUB_SHA::7}" >> $GITHUB_ENV
+      - name: Remove Previous Build Artifacts
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.issue;
+            (await github.rest.actions.listArtifactsForRepo({ owner, repo })).data.artifacts
+              .filter(({ name }) => (name.startsWith('pdf-over-${{ github.event.pull_request.number || github.ref_name }}-') && name.endsWith('linux-x86_64')))
+              .forEach(({ id, name }) => { console.log('Deleting '+name+' ('+id+')'); github.rest.actions.deleteArtifact({ owner, repo, artifact_id: id }); });
+      - name: Set executable permissions
+        run: chmod +x pdf-over-build/*.sh pdf-over-build/jre/bin/*
+      - name: Set executable permissions
+        run: bash .github/helper/debian-package-builder.sh
+      #- name: Tar bundle
+      #  run: tar -C pdf-over-build -cvf pdf-over.tar ./
+      #- name: Upload Build Artifacts
+      #  uses: actions/upload-artifact@v3
+      #  with:
+      #    name: pdf-over-${{ github.event.pull_request.number || github.ref_name }}-${{ env.commit_sha }}-linux-x86_64
+      #    path: pdf-over.tar
+
+permissions:
+    contents: read
+    #actions: write

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -19,6 +19,10 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           cache: maven
+      - name: Install Debian Package Builder dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install packaging-dev git-buildpackage moreutils
       - name: Build with Maven
         run: mvn -B clean install -Plinux -Pci-build -Dno-native-profile
       - name: Describe current commit
@@ -33,7 +37,9 @@ jobs:
               .forEach(({ id, name }) => { console.log('Deleting '+name+' ('+id+')'); github.rest.actions.deleteArtifact({ owner, repo, artifact_id: id }); });
       - name: Set executable permissions
         run: chmod +x pdf-over-build/*.sh pdf-over-build/jre/bin/*
-      - name: Set executable permissions
+      - name: Generated Debian Changelog
+        run: bash .github/helper/debian-changelog-generator.sh
+      - name: Run PDF-Over Debian Package Builder
         run: bash .github/helper/debian-package-builder.sh
       #- name: Tar bundle
       #  run: tar -C pdf-over-build -cvf pdf-over.tar ./

--- a/.github/workflows/build-linux-debian.yaml
+++ b/.github/workflows/build-linux-debian.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: pdf-over-nightly-${{ env.commit_sha }}-debian
-          path: pdf-over-build/pdf-over-nightly.deb
+          path: pdf-over-build/*.deb
       - name: Init Nightly PPA
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Add GitHub action (`.github/workflows/build-linux-debian.yaml` to build (nightly) Debian packages of all commits on the main branch.

The action

- builds the software, as in the existing build-linux action
- generates a Debian package changelog (using `.github/helper/debian-changelog-generator.sh`)
- packages it using `.github/helper/debian-package-builder.sh` and [fpm](https://fpm.readthedocs.io/) 
- Pushes the .deb package to our nightly PPA repo (https://github.com/a-sit/ppa-nightly)
  - From there, the PPA repo's CI should sign the repo and re-deploy the PPA to https://a-sit.github.io/ppa-nightly 