### PR TITLE
Fix Debian dependency issue

### DIFF
--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -59,7 +59,7 @@ fpm \
   --version $VERSION \
   --architecture $ARCH \
   --deb-upstream-changelog debian/changelog \
-  --depends bash --depends "default-jre | java-runtime (>= 21)" \
+  --depends bash --depends "default-jre (>= 1.21) | java-runtime (>= 21)" \
   --description "PDF-Over is your tool for frequent & efficient PDF signing." \
   --url "https://technology.a-sit.at/en/pdf-over/" \
   --vendor "A-SIT <software@egiz.gv.at>" \

--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -59,7 +59,7 @@ fpm \
   --version $VERSION \
   --architecture $ARCH \
   --deb-upstream-changelog debian/changelog \
-  --depends bash --depends "default-jre (>= 1.21) | java-runtime (>= 21)" \
+  --depends bash --depends "java-runtime (>= 21)" \
   --description "PDF-Over is your tool for frequent & efficient PDF signing." \
   --url "https://technology.a-sit.at/en/pdf-over/" \
   --vendor "A-SIT <software@egiz.gv.at>" \


### PR DESCRIPTION
Fixes the dependency string of the Debian package for the Nightly PPA. Thereby resolves #136.

There are now some containers available to verify this:
https://github.com/a-sit/ppa-nightly/tree/main/.github/testing

As expected, the install now works for Ubuntu 24.04 and newer, and the upcoming Debian Trixie (13), but _not_ the current Debian Bookworm (12). [Debian Tricksie](https://wiki.debian.org/DebianTrixie) is already in hard freeze and will be released soon, so I won't fix the issue for bookworm (Java version too old).  