### PR TITLE
Switch from `org.eclipse.swt` to `org.eclipse.platform`

### DIFF
--- a/pdf-over-commons/pom.xml
+++ b/pdf-over-commons/pom.xml
@@ -17,9 +17,9 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.swt</groupId>
-			<artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-			<version>4.35</version>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.swt.gtk.linux.aarch64</artifactId>
+			<version>3.129.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pdf-over-gui/pom.xml
+++ b/pdf-over-gui/pom.xml
@@ -12,12 +12,12 @@
 		<pdfover-build.root-dir>${project.basedir}${file.separator}..</pdfover-build.root-dir>
 		<pdfover-build.output-dir>${pdfover-build.root-dir}/pdf-over-build</pdfover-build.output-dir>
 		<pdfover-build.staging-dir>${project.build.directory}/staging/${pdfover-build.output-filename}</pdfover-build.staging-dir>
-		<pdfover-build.swt-version>4.35</pdfover-build.swt-version>
+		<pdfover-build.swt-version>3.129.0</pdfover-build.swt-version>
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.swt</groupId>
+			<groupId>org.eclipse.platform</groupId>
 			<artifactId>${pdfover-build.swt-artifact-id}</artifactId>
 			<version>${pdfover-build.swt-version}</version>
 		</dependency>
@@ -191,7 +191,7 @@
 							<overWriteSnapshots>true</overWriteSnapshots>
 							<overWriteIfNewer>true</overWriteIfNewer>
 							<excludeScope>system</excludeScope> <!-- this excludes tools.jar, e.g. -->
-							<excludeGroupIds>org.codehaus.izpack,org.eclipse.swt</excludeGroupIds>
+							<excludeGroupIds>org.codehaus.izpack,org.eclipse.platform</excludeGroupIds>
 						</configuration>
 					</execution>
 					<execution>
@@ -204,7 +204,7 @@
 						<configuration>
 							<artifactItems>
 								<artifactItem>
-									<groupId>org.eclipse.swt</groupId>
+									<groupId>org.eclipse.platform</groupId>
 									<artifactId>${pdfover-build.swt-artifact-id}</artifactId>
 									<version>${pdfover-build.swt-version}</version>
 									<type>jar</type>


### PR DESCRIPTION
No need to self host under your `internal-repo` https://apps.egiz.gv.at/maven/org/eclipse/swt/

Background:
While getting PDF-Over working on Linux aarch64, the build failed, complaining that the `org.eclipse.swt.gtk.linux.aarch64` artifact can not be fetched. Turns out that neither on 
- your internal maven repo https://apps.egiz.gv.at/maven/org/eclipse/swt/
- nor on maven central https://repo1.maven.org/maven2/org/eclipse/swt/

the linux aarch64 classifier exists (and Maven central does not even host new releases of swt under that groupid...).

So I was looking around on https://eclipse.dev/eclipse/swt/ and https://github.com/eclipse-platform/eclipse.platform.swt and the maven coordinates where they say they host the swt artifacts is `org.eclipse.platform` under https://repo1.maven.org/maven2/org/eclipse/platform/.

And indeed its there, they even publish aarch64 artifacts:

<img width="370" alt="image" src="https://github.com/user-attachments/assets/988dc005-c8c6-41c3-9a46-ed15fdf2cf05" />


The only thing that made me wonder is the versioning: Currently in PDF-Over you depend on version 4.35 from the `org.eclipse.swt` groupid, but in `org.eclipse.platform`  all versions are on 3.x

Turns out there is this very interesting post:
- https://github.com/eclipse-platform/eclipse.platform.swt/discussions/1370

So reading the replies, my understanding is that the artifacts they publish on maven central under the `org.eclipse.platform` should be just the same like the ones you can download from the website ([here at the bottom](https://download.eclipse.org/eclipse/downloads/drops4/R-4.38-202512010920/) swt 4.38) or from [the archives](https://archive.eclipse.org/eclipse/downloads/) (like the 4.35 one).

So lets check this:
From https://archive.eclipse.org/eclipse/downloads/drops4/R-4.35-202502280140/ download the `swt-4.35-gtk-linux-x86_64.zip` file and unpack it and also unpack the `swt.jar` file inside it. 
Turns out version 4.35 was released in March 2025 (see its [git tag](https://github.com/eclipse-platform/eclipse.platform.swt/releases/tag/R4_35)), we therefore download version 3.129.0 of the `org.eclipse.platform` groupid, as it was published around the same time: https://repo1.maven.org/maven2/org/eclipse/platform/org.eclipse.swt.gtk.linux.x86_64/3.129.0/ - again unpack the jar.
If you now compare the contents of the two unpacked jar files, you will see that they are 99% the same (talking about byte comparison, not just doing `ls` or `tree`), just the manifest files differ slightly and some property files got removed - I guess this was some cleanup task.
But anyway, this shows that we can just replace 4.35 with 3.129.0.
And even more: If you download the jar from your internal repo (https://apps.egiz.gv.at/maven/org/eclipse/swt/org.eclipse.swt.gtk.linux.x86_64/4.35/) and compare its content with the two other jars, you will again see the content is 99% the same, except the manifest and some cleaned up property files (again, just like before).

Therefore I am very confident we can just switch the groupId to `org.eclipse.platform` and the 3.x versioning, which gives us the benefits of
- Not needing to take care of self hosting (no maintenance cost)
- Having all the classifiers of the artifact available (like aarch64)