### PR TITLE
Fix app icon of debian nightly build under Wayland

### DIFF
--- a/.github/helper/debian-package-builder.sh
+++ b/.github/helper/debian-package-builder.sh
@@ -7,6 +7,7 @@ set -o pipefail  # don't hide errors within pipes
 # config:
 NAME="pdf-over-nightly"
 FULLNAME="PDF-Over Nightly"
+DESKTOPNAME="PDF-Over"
 VERSION="`date +"%Y%m%d.%H%M%S"`"
 ARCH="all"
 JAR_TARGET="/usr/share/java/$NAME"
@@ -36,7 +37,7 @@ EOF
 chmod +x $NAME.sh
  
 
-cat > $NAME.desktop << EOF
+cat > $DESKTOPNAME.desktop << EOF
 [Desktop Entry]
 Version=$VERSION
 Type=Application
@@ -66,7 +67,7 @@ fpm \
   --maintainer "A-SIT <software@egiz.gv.at>" \
   $jar_files \
   $NAME.sh=/usr/bin/$NAME \
-  $NAME.desktop=/usr/share/applications/$NAME.desktop \
+  $DESKTOPNAME.desktop=/usr/share/applications/$DESKTOPNAME.desktop \
   icons/icon144x144.png=/usr/share/pixmaps/$NAME.png
 
 # next: upload/publish $NAME-$VERSION-$ARCH.deb


### PR DESCRIPTION
When installing PDF-Over for linux from the download page, the desktop file that gets installed is placed under `~/.local/share/applications/PDF-Over.desktop`. Which is correct.

If that file name would be different, the application icon will not be shown correctly anymore in the title bar when running under Wayland (`GDK_BACKEND=wayland`) under DEs like KDE Plasma.
Why? Because wayland is looking for information about the application in it's corresponding desktop file. And to look up the desktop file it uses the application's app-id. You can find that app id by running:
```
# Assuming pdf-over got installed in `/usr/share/java/`
$ WAYLAND_DEBUG=1 GDK_BACKEND=wayland java -cp '/usr/share/java/pdf-over/*' at.asit.pdfover.gui.Main "$@"
...
[ 583800.618] {Default Queue}  -> xdg_toplevel#37.set_app_id("PDF-Over")
...
```
So it looks up information about the app in `PDF-Over.desktop`.

I did not test this debian build, but my guess is, that when running that debian nightly install via

```
GDK_BACKEND=wayland java -cp '/usr/share/java/pdf-over/*' at.asit.pdfover.gui.Main "$@"`
```

the application icon under KDE will look like this:
<img width="52" height="84" alt="image" src="https://github.com/user-attachments/assets/83f7a4af-d9b8-4190-a5db-c8f22cf36ac1" />
instead of this
<img width="54" height="84" alt="image" src="https://github.com/user-attachments/assets/f45d1562-d102-448e-bfb1-4a85c159de84" />


I am using the Arch Linux AUR and was facing the same problem, you can read my comment there: https://aur.archlinux.org/packages/pdf-over (I hope the AUR maintainer will fix that soon).

Like said, I did not test this, but I just think that this Debian build currently shows the wrong icon. Maybe you can test that. 

Thanks!